### PR TITLE
Continue processing on failure

### DIFF
--- a/src/main/scala/com/gu/Main.scala
+++ b/src/main/scala/com/gu/Main.scala
@@ -29,12 +29,23 @@ object Main extends App with LazyLogging {
 
 //      logger.info(s"woohoo $invoice")
 
-      val cancelInvoiceResponse = ZuoraClient.cancelInvoice(invoice)
-      if (cancelInvoiceResponse.Success) {
-        successfullyCancelledCount = successfullyCancelledCount + 1
-        logger.info(s"$successfullyCancelledCount - ${invoice.`Invoice.InvoiceNumber`} successfully cancelled")
-      } else {
-        Abort(s"Failed to cancel invoice $invoice. Fix and resume from ${invoice.`Invoice.InvoiceNumber`}: $cancelInvoiceResponse")
+      try {
+        val cancelInvoiceResponse = ZuoraClient.cancelInvoice(invoice)
+        if (cancelInvoiceResponse.Success) {
+          successfullyCancelledCount = successfullyCancelledCount + 1
+          logger.info(s"$successfullyCancelledCount - ${invoice.`Invoice.InvoiceNumber`} successfully cancelled")
+        } else {
+          logger.error(
+            s"Failed to cancel invoice $invoice. Fix and resume from ${invoice.`Invoice.InvoiceNumber`}: " +
+            s"$cancelInvoiceResponse"
+          )
+        }
+      } catch {
+        case e: Throwable =>
+          logger.error(
+            s"Failed to cancel invoice $invoice. Fix and resume from ${invoice.`Invoice.InvoiceNumber`}",
+            e
+          )
       }
   }
 


### PR DESCRIPTION
Adding code to catch and log failures in calls to the zuora cancel invoice endpoint, rather than failing and exiting.